### PR TITLE
[JARVIS] Code quality: formatMergedTitle is exported but never called

### DIFF
--- a/src/components/DuplicateList.tsx
+++ b/src/components/DuplicateList.tsx
@@ -2,6 +2,9 @@
 
 import type { DuplicateGroup } from "@/types";
 import { useState } from "react";
+import { formatMergedTitle } from "@/lib/duplicate-detector";
+
+type TitleFormat = "full" | "count-only" | "names-only";
 
 interface DuplicateListProps {
   groups: DuplicateGroup[];
@@ -16,6 +19,7 @@ export function DuplicateList({
 }: DuplicateListProps) {
   const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
   const [editingTitle, setEditingTitle] = useState<string>("");
+  const [titleFormat, setTitleFormat] = useState<TitleFormat>("full");
   const [mergingIndex, setMergingIndex] = useState<number | null>(null);
 
   if (groups.length === 0) {
@@ -26,10 +30,17 @@ export function DuplicateList({
     if (expandedIndex === index) {
       setExpandedIndex(null);
       setEditingTitle("");
+      setTitleFormat("full");
     } else {
       setExpandedIndex(index);
+      setTitleFormat("full");
       setEditingTitle(groups[index].mergedTitle);
     }
+  };
+
+  const handleFormatChange = (group: DuplicateGroup, format: TitleFormat) => {
+    setTitleFormat(format);
+    setEditingTitle(formatMergedTitle(group.baseTitle, group.attendees, format));
   };
 
   const handleMerge = async (group: DuplicateGroup, index: number) => {
@@ -188,6 +199,28 @@ export function DuplicateList({
                   <label className="label-caps block mb-3">
                     Merged Event Title
                   </label>
+                  <div className="flex gap-2 mb-3">
+                    {(
+                      [
+                        { value: "full", label: "Full" },
+                        { value: "count-only", label: "Count only" },
+                        { value: "names-only", label: "Names only" },
+                      ] as { value: TitleFormat; label: string }[]
+                    ).map(({ value, label }) => (
+                      <button
+                        key={value}
+                        type="button"
+                        onClick={() => handleFormatChange(group, value)}
+                        className={`px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors cursor-pointer ${
+                          titleFormat === value
+                            ? "bg-amber-500/20 text-amber-300 border-amber-500/40"
+                            : "bg-slate-700/50 text-slate-400 border-slate-600 hover:border-slate-500 hover:text-slate-300"
+                        }`}
+                      >
+                        {label}
+                      </button>
+                    ))}
+                  </div>
                   <input
                     type="text"
                     value={editingTitle}


### PR DESCRIPTION
Closes #6

Implements option 1 from the issue: wire up `formatMergedTitle` so it is actually used.

## What changed

**`src/components/DuplicateList.tsx`**
- Imports `formatMergedTitle` from `@/lib/duplicate-detector`
- Adds a `TitleFormat` type (`"full" | "count-only" | "names-only"`)
- Adds `titleFormat` state that resets when a group is collapsed
- Adds `handleFormatChange` which calls `formatMergedTitle` and updates the editable title field
- Renders three toggle buttons (Full / Count only / Names only) above the title input when a group is expanded; the active format is highlighted in amber

The user can still manually edit the generated title after picking a format — existing behaviour is preserved.

Implemented by JARVIS.